### PR TITLE
Improved performance of adding notes to a track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+#MASTER
+
+###Made `addnotes` significantly faster.
+
+The old version was calling ´addevent!´ for each `NOTEON` or `NOTEOFF` event.
+`addevent!` always starts to search the MIDITrack for the correct insertion position
+at the beginning of the track. Now we implemented a new adding function
+`addevent_hint` which is able to skip all `TrackEvent`s that surely lay before
+the new event to add. For $N$ notes in successive order this reduces the complexity
+of the algorithm from $\mathcal O(N^2)$ to $\mathcal O(N)$ which leads to
+significant speedup.
+
+###New `addevents!` function
+
+Now there is not only `addevent!` to add events to an existing track, but also
+`addevents!` which is significantly faster than calling `addevent!` many times,
+because it uses the new `addevent_hint` function to add the events.
+
+Please replace code like
+```
+for i = 1:X
+    addevent!(track, positions[i], events[i])
+end
+```
+by
+```
+addevents!(track, positions, events)
+```
+to increase performance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,28 @@
-#MASTER
+# MASTER
 
-###Made `addnotes` significantly faster.
+### Made `addnotes` significantly faster.
 
 The old version was calling ´addevent!´ for each `NOTEON` or `NOTEOFF` event.
 `addevent!` always starts to search the MIDITrack for the correct insertion position
 at the beginning of the track. Now we implemented a new adding function
 `addevent_hint` which is able to skip all `TrackEvent`s that surely lay before
 the new event to add. For $N$ notes in successive order this reduces the complexity
-of the algorithm from $\mathcal O(N^2)$ to $\mathcal O(N)$ which leads to
-significant speedup.
+of the algorithm from O(N²) to O(N) which leads to significant speedup.
 
-###New `addevents!` function
+### New `addevents!` function
 
 Now there is not only `addevent!` to add events to an existing track, but also
 `addevents!` which is significantly faster than calling `addevent!` many times,
 because it uses the new `addevent_hint` function to add the events.
 
 Please replace code like
-```
+``` julia
 for i = 1:X
     addevent!(track, positions[i], events[i])
 end
 ```
 by
-```
+``` julia
 addevents!(track, positions, events)
 ```
 to increase performance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,13 @@
-# MASTER
+# master
 
-### Made `addnotes` significantly faster.
+## New `addevents!` function
 
-The old version was calling ´addevent!´ for each `NOTEON` or `NOTEOFF` event.
-`addevent!` always starts to search the MIDITrack for the correct insertion position
-at the beginning of the track. Now we implemented a new adding function
-`addevent_hint` which is able to skip all `TrackEvent`s that surely lay before
-the new event to add. For $N$ notes in successive order this reduces the complexity
-of the algorithm from O(N²) to O(N) which leads to significant speedup.
+* Now there is not only `addevent!` to add events to an existing track, but also
+  `addevents!` which is significantly faster than calling `addevent!` many times,
+  because it uses the new `addevent_hint` function to add the events. Use `addevents!` to add multiple events in one go.
 
-### New `addevents!` function
+* This also made `addnotes` significantly faster.
 
-Now there is not only `addevent!` to add events to an existing track, but also
-`addevents!` which is significantly faster than calling `addevent!` many times,
-because it uses the new `addevent_hint` function to add the events.
-
-Please replace code like
-``` julia
-for i = 1:X
-    addevent!(track, positions[i], events[i])
-end
-```
-by
-``` julia
-addevents!(track, positions, events)
-```
-to increase performance.
+* Internally we implemented a new adding function
+  `addevent_hint!` which is able to skip all `TrackEvent`s that surely lay before
+  the new event to add.

--- a/src/miditrack.jl
+++ b/src/miditrack.jl
@@ -185,7 +185,7 @@ function addevent_hint!(track::MIDITrack, time::Integer, newevent::TrackEvent,
 end
 
 """
-    addevents!(track::MIDITrack, times::Vector{Int}, events::Vector{TrackEvent})
+    addevents!(track::MIDITrack, times::Vector{Int}, events::Vector{<:TrackEvent})
 
 Add given `events` to given `track` at given `times`, internally
 doing all translations from absolute time to relative time.

--- a/src/miditrack.jl
+++ b/src/miditrack.jl
@@ -104,6 +104,9 @@ end
     addevent!(track::MIDITrack, time::Int, event::TrackEvent)
 Add an event to the `track` at given `time`. The `time` is in absolute time,
 not relative.
+
+If you want to add multiple events in one go, you should use the [`addevents!`](@ref)
+function instead.
 """
 function addevent!(track::MIDITrack, time::Integer, newevent::TrackEvent)
     tracktime = 0
@@ -146,7 +149,7 @@ This shortens the search for the correct position for `event` by skipping all
 Returns the index and absolute time of the added event.
 """
 function addevent_hint!(track::MIDITrack, time::Integer, newevent::TrackEvent,
-                    eventindex::Int, eventtime::Int)
+                    eventindex::Integer, eventtime::Integer)
     # start at known position
     eventtime > time && throw(ArgumentError("Eventtime has to be smaller than time."))
     tracktime = eventtime
@@ -185,12 +188,15 @@ function addevent_hint!(track::MIDITrack, time::Integer, newevent::TrackEvent,
 end
 
 """
-    addevents!(track::MIDITrack, times::Vector{Int}, events::Vector{<:TrackEvent})
+    addevents!(track::MIDITrack, times, events)
 
 Add given `events` to given `track` at given `times`, internally
 doing all translations from absolute time to relative time.
+
+Using this function is more efficient than a loop over single [`addevent!`](@ref)
+calls.
 """
-function addevents!(track::MIDITrack, times::Vector{Int}, events::Vector{TrackEvent})
+function addevents!(track::MIDITrack, times::AbstractArray{Int}, events)
 
     # get a permutation that gives temporal order
     if issorted(times)


### PR DESCRIPTION
Closes #100
PROBLEM: 
`addnotes!`  had bad runtime, because it just called `addevent!` for a `NOTEON` and a `NOTEOFF` event. `addevent!` always starts searching for the correct position of an event at the beginning of the track.
SOLUTION:
I implemented a new function `addevent_hint!` which also takes the index and absolute time of a known `TrackEvent` and starts searching at that point. For successive events this changes the runtime behavior from quadratic to linear in the amount of events.
The `addnotes` function now first generates all events needed to encode the notes and then orders them successively. It then calls `addevent_hint` with the position where the last event was added to add a new event.
+ Tests for every new thing (comments there should be explaining enough)