### PR TITLE
Fix deprecations on Julia v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ os:
   - osx
 julia:
   - 0.6
+  - 0.7
+  - nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+Compat 0.33

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,8 +24,8 @@ install:
   - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
         https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-throw "There are newer queued builds for this pull request, failing early." }
-  # Download most recent Julia Windows binary
+        throw "There are newer queued builds for this pull request, failing early." }
+# Download most recent Julia Windows binary
   - ps: (new-object net.webclient).DownloadFile(
         $env:JULIA_URL,
         "C:\projects\julia-binary.exe")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,10 @@ environment:
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:
@@ -16,7 +20,12 @@ notifications:
 
 install:
   - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
+  # If there's a newer build queued for the same PR, cancel this one
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+throw "There are newer queued builds for this pull request, failing early." }
+  # Download most recent Julia Windows binary
   - ps: (new-object net.webclient).DownloadFile(
         $env:JULIA_URL,
         "C:\projects\julia-binary.exe")

--- a/src/MIDI.jl
+++ b/src/MIDI.jl
@@ -3,6 +3,8 @@ A Julia library for reading and writing MIDI files.
 """
 module MIDI
 
+using Compat: @warn
+
 include("note.jl")
 include("trackevent.jl")
 include("miditrack.jl")

--- a/src/MIDI.jl
+++ b/src/MIDI.jl
@@ -3,7 +3,7 @@ A Julia library for reading and writing MIDI files.
 """
 module MIDI
 
-using Compat: @warn
+using Compat: @warn, undef
 
 include("note.jl")
 include("trackevent.jl")

--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -38,7 +38,7 @@ function readMIDIfile(filename::AbstractString)
 
     MIDIfile = MIDIFile()
     # Check that it's a valid MIDI file - first four bytes should spell MThd
-    mthd = join(map(Char, read(f, UInt8, 4)))
+    mthd = join(map(Char, read!(f, Array{UInt8}(undef, 4))))
     if mthd != MTHD
         error("Not a valid MIDI file. Expected first 4 bytes to spell 'MThd', got $(mthd)")
     end
@@ -70,7 +70,7 @@ function writeMIDIfile(filename::AbstractString, data::MIDIFile)
 
     f = open(filename, "w")
 
-    write(f, convert(Array{UInt8, 1}, MTHD)) # File identifier
+    write(f, MTHD) # File identifier
     write(f, hton(convert(UInt32, 6))) # Header length
     write(f, hton(data.format))
     write(f, hton(convert(UInt16, length(data.tracks))))

--- a/src/miditrack.jl
+++ b/src/miditrack.jl
@@ -17,9 +17,9 @@ end
 MIDITrack() = MIDITrack(TrackEvent[])
 
 function readtrack(f::IO)
-    mtrk = join(map(Char, read(f, UInt8, 4)))
+    mtrk = join(map(Char, read!(f, Array{UInt8}(undef, 4))))
     if mtrk != MTRK
-        error("Not a valid MIDI file. Expected MTrk, got $(mtrk) starting at byte $(hex(position(f)-4, 2))")
+        error("Not a valid MIDI file. Expected MTrk, got $(mtrk) starting at byte $(string(position(f)-4, base=16, pad=2))")
     end
     track = MIDITrack()
 
@@ -72,7 +72,7 @@ function readtrack(f::IO)
 end
 
 function writetrack(f::IO, track::MIDITrack)
-    write(f, convert(Array{UInt8, 1}, MTRK)) # Track identifier
+    write(f, MTRK) # Track identifier
 
     writingMIDI = false
     previous_status = UInt8(0)
@@ -296,7 +296,7 @@ Time is absolute, not relative to the last event.
 The `program` must be specified in the range 1-128, **not** in 0-127!
 """
 function programchange(track::MIDITrack, time::Integer, channel::UInt8, program::UInt8)
-    warn("This function has not been tested. Please test it before using "*
+    @warn("This function has not been tested. Please test it before using "*
     "and be kind enough to report whether it worked!")
     program -= 1
     addevent!(track, time, MIDIEvent(0, PROGRAMCHANGE | channel, UInt8[program]))

--- a/src/trackevent.jl
+++ b/src/trackevent.jl
@@ -41,7 +41,7 @@ function readmetaevent(dT::Int, f::IO)
     skip(f, 1) # Skip the 0xff that starts the event
     metatype = read(f, UInt8)
     datalength = readvariablelength(f)
-    data = read(f, UInt8, datalength)
+    data = read!(f, Array{UInt8}(undef, datalength))
 
     MetaEvent(dT, metatype, data)
 end
@@ -101,7 +101,7 @@ function readMIDIevent(dT::Int, f::IO, laststatus::UInt8)
         skip(f, -1)
     end
 
-    data = read(f, UInt8, toread)
+    data = read!(f, Array{UInt8}(undef, toread))
 
     MIDIEvent(dT, statusbyte, data)
 end

--- a/test/midiio.jl
+++ b/test/midiio.jl
@@ -1,5 +1,5 @@
 using MIDI
-using Base.Test
+using Compat.Test
 
 cd(@__DIR__)
 
@@ -11,7 +11,9 @@ cd(@__DIR__)
     notes = getnotes(midi.tracks[4])
 
     @test length(notes.notes) > 1
-    @test start(notes) == 1
+    if VERSION < v"0.7-"
+        @test start(notes) == 1
+    end
     @test notes.tpq == 960
 
     @test notes[1].pitch == 65

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using MIDI
-using Base.Test
+using Compat.Test
 
 include("variablelength.jl")
 include("sysexevent.jl")


### PR DESCRIPTION
The only thing I'm not totally sure about is the change from `write(f, convert(Array{UInt8, 1}, MTHD))` to `write(f, MTHD)`. It should be fine, but I'm not sure why the `convert` was necessary to begin with, so I'm not entirely sure it's safe to remove. 

