### PR TITLE
abide to scientific note notation

### DIFF
--- a/test/note.jl
+++ b/test/note.jl
@@ -26,6 +26,7 @@ end
         @test n == replace(pitch_to_name(name_to_pitch(n)), "♯" => "#")
     end
     @test pitch_to_name(name_to_pitch("E#7")) == "F7"
-    @test pitch_to_name(name_to_pitch("B#")) == "C6"
-    @test pitch_to_name(name_to_pitch("F♯")) == "F♯5"
+    @test pitch_to_name(name_to_pitch("B#")) == "C5"
+    @test pitch_to_name(name_to_pitch("F♯")) == "F♯4"
+    @test name_to_pitch("C4") == 60
 end


### PR DESCRIPTION
See http://newt.phys.unsw.edu.au/jw/notes.html
and https://en.wikipedia.org/wiki/C_(musical_note) .

In short, C4 corresponds to note midi pitch 60 (midi pitch is an integer in [0,127]), NOT C5. Our previous implementation does not abide by these rules and thus is wrong.