### PR TITLE
Remove 960 ticks upper limit for tpq.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+# v1.7.0
+* Notes constructor allows values of `tpq` greater than `960`.
 # v1.6.0
 * New function `testnotes()` that returns a test set of human-played notes.
 # v1.5.2

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MIDI"
 uuid = "f57c4921-e30c-5f49-b073-3f2f2ada663e"
 repo = "https://github.com/JuliaMusic/MIDI.jl.git"
-version = "1.6.0"
+version = "1.7.0"
 
 [compat]
 julia = "1"

--- a/src/note.jl
+++ b/src/note.jl
@@ -69,13 +69,13 @@ end
 
 # Constructors for Notes:
 function Notes(notes::Vector{N}, tpq::Int = 960) where {N <: AbstractNote}
-    if tpq < 1 || tpq > 960
-        throw(ArgumentError("Ticks per quarter note (tpq) must ∈ [1, 960]"))
+    if tpq < 1
+        throw(ArgumentError("Ticks per quarter note (tpq) must be > 1"))
     end
     Notes{N}(notes, tpq)
 end
 
-Notes() = Notes{Note}(Vector{Note}[], 960)
+Notes() = Notes{Note}(Vector{Note}[], tpq = 960)
 
 # Iterator Interface for notes:
 Base.iterate(n::Notes) = iterate(n.notes)

--- a/src/note.jl
+++ b/src/note.jl
@@ -70,12 +70,12 @@ end
 # Constructors for Notes:
 function Notes(notes::Vector{N}, tpq::Int = 960) where {N <: AbstractNote}
     if tpq < 1
-        throw(ArgumentError("Ticks per quarter note (tpq) must be > 1"))
+        throw(ArgumentError("Ticks per quarter note (tpq) must be >= 1"))
     end
     Notes{N}(notes, tpq)
 end
 
-Notes() = Notes{Note}(Vector{Note}[], tpq = 960)
+Notes(; tpq = 960) = Notes{Note}(Vector{Note}[], tpq)
 
 # Iterator Interface for notes:
 Base.iterate(n::Notes) = iterate(n.notes)


### PR DESCRIPTION
Remove 960 ticks upper limit for tpq, add tpq keyword argument for `Notes()` constructor function.