### PR TITLE
Add tempochanges and update ms_per_tick to use qpm instead of BPM

### DIFF
--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -256,7 +256,7 @@ end
 """
     tempochanges(midi)
 Return a vector of (position, tempo) tuples for all the tempo events in the given `MIDIFile`
-where position is expressed in ticks and tempo in quarter notes per minute.
+where position is in absolute time (from the beginning of the file) in ticks and tempo is in quarter notes per minute.
 Returns [(0, 120.0)] if there are no tempo events.
 """
 function tempochanges(midi::MIDIFile)

--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -256,7 +256,8 @@ end
 """
     tempochanges(midi)
 Return a vector of (position, tempo) tuples for all the tempo events in the given `MIDIFile`
-where position is in absolute time (from the beginning of the file) in ticks and tempo is in quarter notes per minute.
+where position is in absolute time (from the beginning of the file) in ticks
+and tempo is in quarter notes per minute.
 Returns [(0, 120.0)] if there are no tempo events.
 """
 function tempochanges(midi::MIDIFile)

--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -255,7 +255,8 @@ end
 
 """
     tempochanges(midi)
-Return the position and tempo in quarter notes per minute for all the Tempo events in the given `MIDIFile`.
+Return a vector of (position, tempo) tuples for all the tempo events in the given `MIDIFile`
+where position is expressed in ticks and tempo in quarter notes per minute.
 Returns [(0, 120.0)] if there are no tempo events.
 """
 function tempochanges(midi::MIDIFile)

--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -1,5 +1,5 @@
 export MIDIFile, readMIDIFile, writeMIDIFile
-export BPM, bpm, qpm, time_signature, get_tempo_changes, ms_per_tick
+export BPM, bpm, qpm, time_signature, tempochanges, ms_per_tick
 
 """
     MIDIFile <: Any
@@ -254,11 +254,11 @@ function time_signature(t::MIDI.MIDIFile)
 end
 
 """
-    get_tempo_changes(midi)
+    tempochanges(midi)
 Return the position and tempo in quarter notes per minute for all the Tempo events in the given `MIDIFile`.
 Returns [(0, 120.0)] if there are no tempo events.
 """
-function get_tempo_changes(midi::MIDIFile)
+function tempochanges(midi::MIDIFile)
     # Stores (position, tempo) pairs
     tempo_changes = [(0, 120.0)]
     position = 0

--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -254,13 +254,13 @@ function time_signature(t::MIDI.MIDIFile)
 end
 
 """
-    ms_per_tick(tpq, bpm)
+    ms_per_tick(tpq, qpm)
     ms_per_tick(midi::MIDIFile)
 Return how many miliseconds is one tick, based
-on the beats per minute `bpm` and ticks per quarter note `tpq`.
+on the quarter notes per minute `qpm` and ticks per quarter note `tpq`.
 """
-ms_per_tick(midi::MIDI.MIDIFile, bpm = BPM(midi)) = ms_per_tick(midi.tpq, bpm)
-ms_per_tick(tpq, bpm) = (1000*60)/(bpm*tpq)
+ms_per_tick(midi::MIDI.MIDIFile, qpm = qpm(midi)) = ms_per_tick(midi.tpq, qpm)
+ms_per_tick(tpq, qpm) = (1000*60)/(qpm*tpq)
 
 getnotes(midi::MIDIFile, trackno = midi.format == 0 ? 1 : 2) = 
 getnotes(midi.tracks[trackno], midi.tpq)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -3,6 +3,10 @@
     @test time_signature(midi) == "4/4"
     @test qpm(midi) ≈ 130.00013
     @test bpm(midi) ≈ 130.00013
+
+    first_tempo_event = get_tempo_changes(midi)[1]
+    @test first_tempo_event[1] == 0
+    @test first_tempo_event[2] ≈ 130.00013
 end
 
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -4,7 +4,7 @@
     @test qpm(midi) ≈ 130.00013
     @test bpm(midi) ≈ 130.00013
 
-    first_tempo_event = get_tempo_changes(midi)[1]
+    first_tempo_event = tempochanges(midi)[1]
     @test first_tempo_event[1] == 0
     @test first_tempo_event[2] ≈ 130.00013
 end


### PR DESCRIPTION
Hi, I've added get_tempo_changes to get all the tempo changes in the midi file. I've tested it on a local midi file which has more than one tempo event and it worked correctly.

I've also updated the ms_per_tick function to use qpm instead of BPM (which is deprecated).