### PR TITLE
Allow read/write for .MID and .midi files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MIDI"
 uuid = "f57c4921-e30c-5f49-b073-3f2f2ada663e"
 repo = "https://github.com/JuliaMusic/MIDI.jl.git"
-version = "1.12.0"
+version = "1.12.1"
 
 [compat]
 julia = "1"

--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -46,7 +46,8 @@ end
 Read a file into a `MIDIFile` data type.
 """
 function readMIDIFile(filename::AbstractString)
-    if length(filename) < 4 || filename[end-3:end] != ".mid"
+    # Filename does not end in ".mid", ".MID", ".midi"
+    if match(r"(?i)(\.mid)i?$", filename) === nothing
 		filename *= ".mid"
     end
     f = open(filename)
@@ -84,7 +85,7 @@ Write a `MIDIFile` as a ".mid" file to the given filename.
 Create a `MIDIFile` directly from `notes`, using format 1.
 """
 function writeMIDIFile(filename::AbstractString, data::MIDIFile)
-    if length(filename) < 4 || filename[end-3:end] != ".mid" && filename[end-3:end] != ".MID"
+    if match(r"(?i)(\.mid)i?$", filename) === nothing
       filename *= ".mid"
     end
 
@@ -103,10 +104,6 @@ function writeMIDIFile(filename::AbstractString, data::MIDIFile)
 end
 
 function writeMIDIFile(filename::AbstractString, notes::Notes)
-    if length(filename) < 4 || lowercase(filename[end-3:end]) != ".mid"
-      filename *= ".mid"
-    end
-
     track = MIDITrack()
     addnotes!(track, notes)
     midi = MIDIFile(1, notes.tpq, [track])

--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -47,7 +47,7 @@ Read a file into a `MIDIFile` data type.
 """
 function readMIDIFile(filename::AbstractString)
     # Filename does not end in ".mid", ".MID", ".midi"
-    if match(r"(?i)(\.mid)i?$", filename) === nothing
+    if match(r"\.(mid|MID|midi)$", filename) === nothing
 		filename *= ".mid"
     end
     f = open(filename)
@@ -85,7 +85,7 @@ Write a `MIDIFile` as a ".mid" file to the given filename.
 Create a `MIDIFile` directly from `notes`, using format 1.
 """
 function writeMIDIFile(filename::AbstractString, data::MIDIFile)
-    if match(r"(?i)(\.mid)i?$", filename) === nothing
+    if match(r"\.(mid|MID|midi)$", filename) === nothing
       filename *= ".mid"
     end
 


### PR DESCRIPTION
Hi, previously we were able to read `.mid` files and write both `.mid` and `.MID` files. Now we can read/write `.mid`, `.MID` and `.midi` files. 
`.MID` and `.midi` are also quite common so it would be great to be able to read/write them. The extensions differ only by their name so the filename check was alone changed. 