### PR TITLE
Parse and test negative octaves. closes #144

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MIDI"
 uuid = "f57c4921-e30c-5f49-b073-3f2f2ada663e"
 repo = "https://github.com/JuliaMusic/MIDI.jl.git"
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/src/note.jl
+++ b/src/note.jl
@@ -170,16 +170,18 @@ function name_to_pitch(name)
     if length(pe) >= 2
         if pe[2] == "#" || pe[2] == "♯"
             x = 1
+            deleteat!(pe,2)
         elseif pe[2] == "b" || pe[2] == "♭"
             x = -1
+            deleteat!(pe,2)
         end
     end
-    if isdigit(first(last(pe)))
-        octave = parse(Int, join(filter(isdigit ∘ first, pe)))
-    else
-        octave = 4
+    if length(pe) == 1
+        push!(pe, string(4))
     end
-
+    
+    octave = parse(Int, join(pe[2:end]))
+    
     return pitch + x + 12(octave+1) # lowest possible octave is -1 but pitch starts from 0
 end
 

--- a/test/note.jl
+++ b/test/note.jl
@@ -29,6 +29,8 @@ end
 
     n = Note(0, 1, 1, 1)
     @test pitch_to_name(n.pitch) == "C-1"
+
+    @test all([name_to_pitch(pitch_to_name(i)) == i for i in 0:88])
 end
 
 @testset "copying notes" begin

--- a/test/note.jl
+++ b/test/note.jl
@@ -30,7 +30,7 @@ end
     n = Note(0, 1, 1, 1)
     @test pitch_to_name(n.pitch) == "C-1"
 
-    @test all([name_to_pitch(pitch_to_name(i)) == i for i in 0:88])
+    @test all([name_to_pitch(pitch_to_name(i)) == i for i in 0:255])
 end
 
 @testset "copying notes" begin


### PR DESCRIPTION
This fixes #144 : name_to_pitch fails for negative octave

It includes a test for a relevant set of pitches:

```{julia}
@test all([name_to_pitch(pitch_to_name(i)) == i for i in 0:88])
```

Before patch:

```{julia}
julia> join(name_to_pitch.([pitch_to_name(i)  for i in 0:24]), ", ")
"24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24"
```

With patch:

```{julia}
julia> join(name_to_pitch.([pitch_to_name(i)  for i in 0:24]), ", ")
"0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24"
```


