### PR TITLE
add a midi meta event 0x21: midi port

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MIDI"
 uuid = "f57c4921-e30c-5f49-b073-3f2f2ada663e"
 repo = "https://github.com/JuliaMusic/MIDI.jl.git"
-version = "2.0.1"
+version = "2.0.2"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/src/events.jl
+++ b/src/events.jl
@@ -24,6 +24,12 @@ const MIDI_EVENTS_DEFS = Dict(
         decode = :(Int.(data)),
         encode = :(UInt8(event.channel))
     ),
+    0x21 => (
+        type = :MIDIPort,
+        fields = ["channel::Int"],
+        decode = :(Int.(data)),
+        encode = :(UInt8(event.channel))
+    ),
     0x2F => (
         type = :EndOfTrackEvent,
         fields = [],


### PR DESCRIPTION
The meta event 0x21 was missing in the dict: MIDI_EVENTS_DEFS. For some midi files that have this meta event, there would be a load error. So, I add 0x21 to it.