### PR TITLE
clean up a few things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.jl.cov
 *.jl.mem
+Manifest.toml

--- a/src/MIDI.jl
+++ b/src/MIDI.jl
@@ -3,6 +3,9 @@ A Julia library for reading and writing MIDI files.
 """
 module MIDI
 
+using FileIO
+using Base.Unicode
+
 include("constants.jl")
 include("note.jl")
 include("trackevent.jl")
@@ -15,8 +18,22 @@ include("convert.jl")
 include("findevents.jl")
 include("deprecations.jl")
 
-
 export testmidi, testnotes
+export DRUMKEY
+export type1totype0, type1totype0!
+export type0totype1, type0totype1!
+export getprogramchangeevents
+export encode
+export trackname, addtrackname!, findtextevents
+export tracknames
+export MIDIFile, readMIDIFile, writeMIDIFile
+export BPM, bpm, qpm, time_signature, tempochanges, ms_per_tick
+export getnotes, addnote!, addnotes!, addevent!, addevents!
+export MIDITrack
+export Note, Notes, AbstractNote, DrumNote
+export pitch_to_name, name_to_pitch
+export TrackEvent, MetaEvent, MIDIEvent, SysexEvent
+export readvariablelength, writevariablelength
 
 """
     testmidi()

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -201,5 +201,3 @@ const DRUMKEY = begin
 	"Crash Cymbal 2" => "A3"
 	)
 end
-
-export DRUMKEY

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -24,8 +24,6 @@ function type1totype0(data::MIDIFile)
 	type1totype0!(newdata)
 end
 
-export type1totype0, type1totype0!
-
 function type0totype1!(data::MIDIFile)
 	if data.format != UInt8(0)
 		error("Got type $(data.format); expecting type 0")
@@ -64,7 +62,6 @@ function type0totype1(data::MIDIFile)
 	type0totype1!(newdata)
 end
 
-export type0totype1, type0totype1!
 
 function insertsorted!(events1::Array{TrackEvent, 1}, 
 					   events2::Array{TrackEvent, 1})
@@ -115,7 +112,6 @@ function getprogramchangeevents(data::MIDIFile)
 	end
 	pgevents
 end
-export getprogramchangeevents
 
 function dochannelsconflict(pgevents)
 	channels = Dict()

--- a/src/events.jl
+++ b/src/events.jl
@@ -1,5 +1,3 @@
-export encode, decode
-
 # Create a map from typebyte to the type definitions (not the actual types)
 const MIDI_EVENTS_DEFS = Dict(
     # MetaEvents

--- a/src/findevents.jl
+++ b/src/findevents.jl
@@ -1,9 +1,6 @@
 # Functions that find special events, like e.g. lyrics, or tracknames
 # are contained here
 
-export trackname, addtrackname!, textevent, findtextevents
-export tracknames
-
 const NOTRACKNAME = "No track name found"
 
 """

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,5 +1,3 @@
-using FileIO
-
 """
     load(filename::File{format"MIDI"})
 Read a file into a `MIDIFile` data type.

--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -1,6 +1,3 @@
-export MIDIFile, readMIDIFile, writeMIDIFile
-export BPM, bpm, qpm, time_signature, tempochanges, ms_per_tick
-
 """
     MIDIFile <: Any
 Type representing a file of MIDI data.
@@ -16,7 +13,7 @@ mutable struct MIDIFile
     tracks::Vector{MIDITrack}
 end
 # Pretty print
-function Base.show(io::IO, midi::MIDIFile) where {N}
+function Base.show(io::IO, midi::MIDIFile)
 	tnames = tracknames(midi)
 	s = "MIDIFile (format=$(Int(midi.format)), tpq=$(midi.tpq)) "
 	if any(!isequal(NOTRACKNAME), tnames) # we have tracknames

--- a/src/miditrack.jl
+++ b/src/miditrack.jl
@@ -1,6 +1,3 @@
-export getnotes, addnote!, addnotes!, addevent!, addevents!
-export MIDITrack
-
 """
     MIDITrack <: Any
 
@@ -16,7 +13,7 @@ mutable struct MIDITrack
 end
 MIDITrack() = MIDITrack(TrackEvent[])
 # Pretty print
-function Base.show(io::IO, t::MIDITrack) where {N}
+function Base.show(io::IO, t::MIDITrack)
     L = length(t.events)
     M = count(x -> x isa MIDIEvent, t.events)
     T = count(x -> x isa MetaEvent, t.events)

--- a/src/note.jl
+++ b/src/note.jl
@@ -1,6 +1,3 @@
-export Note, Notes, AbstractNote, DrumNote
-export pitch_to_name, name_to_pitch
-
 abstract type AbstractNote end
 
 """
@@ -119,7 +116,6 @@ Base.copy(notes::Notes) = Notes([copy(n) for n in notes], notes.tpq)
 #######################################################
 # string name <-> midi pitch
 #######################################################
-using Base.Unicode
 const PITCH_TO_NAME = Dict(
 0=>"C", 1=>"C♯", 2=>"D", 3=>"D♯", 4=>"E", 5=>"F", 6=>"F♯", 7=>"G", 8=>"G♯", 9=>"A",
 10 =>"A♯", 11=>"B")

--- a/src/trackevent.jl
+++ b/src/trackevent.jl
@@ -1,5 +1,3 @@
-export TrackEvent, MetaEvent, MIDIEvent, SysexEvent
-
 """
     TrackEvent <: Any
 Abstract supertype for all MIDI events.

--- a/src/variablelength.jl
+++ b/src/variablelength.jl
@@ -1,4 +1,3 @@
-export readvariablelength, writevariablelength
 """
     readvariablelength(f::IO)
 Variable length numbers in MIDI files are represented as a sequence of bytes.


### PR DESCRIPTION
* moved exports and usings to MIDI.jl
* removed nonexistent exports for textevent and decode
* removed unnecesary type param on show methods

some of these changes are a bit opinionated i suppose, but none of it is breaking.

personally I think it makes sense to having all the exports and usings in one place. 

also meaning to ask about `decode`, I couldn't find it defined anywhere (but I would like to be able to decode MIDI messages (from rtmidi) into MIDIEvents)