### PR TITLE
Minor changes to help with multiple-track files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-
+# v2.1.0
+* Default value of `MIDIFile.format` changed from 0 to 1
+* Warning introduced to `fileio_save` for format 0 files with multiple tracks
 # v2.0.0
 ## Breaking
 * `MIDIEvent` and `MetaEvent` are abstract types and they cannot be used directly.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MIDI"
 uuid = "f57c4921-e30c-5f49-b073-3f2f2ada663e"
 repo = "https://github.com/JuliaMusic/MIDI.jl.git"
-version = "2.0.4"
+version = "2.1.0"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/src/io.jl
+++ b/src/io.jl
@@ -36,6 +36,12 @@ function fileio_save(f::File{format"MIDI"}, data::MIDIFile)
 end
 
 function fileio_save(s::Stream{format"MIDI"}, data::MIDIFile)
+	if data.format == UInt8(0) && length(data.tracks) > 1
+		@warn("MIDI file-type 0 only supports a single track. Consider using "*
+        " format 1, or converting your file using type1totype0! to convert "*
+        " type 1 data to type 0 data.")
+	end
+
     write(s, magic(format"MIDI"))
 
     write(s, hton(convert(UInt32, 6))) # Header length

--- a/src/midifile.jl
+++ b/src/midifile.jl
@@ -28,7 +28,7 @@ function Base.show(io::IO, midi::MIDIFile)
 end
 
 
-MIDIFile() = MIDIFile(0,960,MIDITrack[])
+MIDIFile() = MIDIFile(1,960,MIDITrack[])
 
 """
     qpm(midi)


### PR DESCRIPTION
As discussed in #152 , this small PR changes the default file type to a 1, and adds a warning when writing files of type 0 which have more than one track