### PR TITLE
Added Frequency conversions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+# v2.1.1
+* New functions `pitch_to_hz ` and `hz_to_pitch `
 # v2.1.0
 * Default value of `MIDIFile.format` changed from 0 to 1
 * Warning introduced to `fileio_save` for format 0 files with multiple tracks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-# v2.1.1
+# v2.2.0
 * New functions `pitch_to_hz ` and `hz_to_pitch `
 # v2.1.0
 * Default value of `MIDIFile.format` changed from 0 to 1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MIDI"
 uuid = "f57c4921-e30c-5f49-b073-3f2f2ada663e"
 repo = "https://github.com/JuliaMusic/MIDI.jl.git"
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MIDI"
 uuid = "f57c4921-e30c-5f49-b073-3f2f2ada663e"
 repo = "https://github.com/JuliaMusic/MIDI.jl.git"
-version = "2.1.1"
+version = "2.2.0"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/src/MIDI.jl
+++ b/src/MIDI.jl
@@ -31,7 +31,7 @@ export getnotes, addnote!, addnotes!, addevent!, addevents!
 export MIDITrack
 export Note, Notes, AbstractNote, DrumNote
 export pitch_to_name, name_to_pitch
-export pitch_to_hz, hz_to_pitch, hz_to_name, name_to_hz
+export pitch_to_hz, hz_to_pitch
 export TrackEvent, MetaEvent, MIDIEvent, SysexEvent
 export readvariablelength, writevariablelength
 

--- a/src/MIDI.jl
+++ b/src/MIDI.jl
@@ -31,7 +31,7 @@ export getnotes, addnote!, addnotes!, addevent!, addevents!
 export MIDITrack
 export Note, Notes, AbstractNote, DrumNote
 export pitch_to_name, name_to_pitch
-export pitch_to_hz
+export pitch_to_hz, pitch, hz_to_pitch, hz_to_name, name_to_hz
 export TrackEvent, MetaEvent, MIDIEvent, SysexEvent
 export readvariablelength, writevariablelength
 

--- a/src/MIDI.jl
+++ b/src/MIDI.jl
@@ -31,7 +31,7 @@ export getnotes, addnote!, addnotes!, addevent!, addevents!
 export MIDITrack
 export Note, Notes, AbstractNote, DrumNote
 export pitch_to_name, name_to_pitch
-export pitch_to_hz, pitch, hz_to_pitch, hz_to_name, name_to_hz
+export pitch_to_hz, hz_to_pitch, hz_to_name, name_to_hz
 export TrackEvent, MetaEvent, MIDIEvent, SysexEvent
 export readvariablelength, writevariablelength
 

--- a/src/MIDI.jl
+++ b/src/MIDI.jl
@@ -31,6 +31,7 @@ export getnotes, addnote!, addnotes!, addevent!, addevents!
 export MIDITrack
 export Note, Notes, AbstractNote, DrumNote
 export pitch_to_name, name_to_pitch
+export pitch_to_hz
 export TrackEvent, MetaEvent, MIDIEvent, SysexEvent
 export readvariablelength, writevariablelength
 

--- a/src/note.jl
+++ b/src/note.jl
@@ -133,9 +133,6 @@ e.g. `A♯3` is printed as `B♭3`.
 
 Reminder: middle C has pitch `60` and is displayed as `C4`.
 """
-function pitch_to_hz(pitch, a4 = 440)
-    return a4 * (2.0 ^ ((pitch- 69.0) / 12.0))
-end
 
 function pitch_to_name(pitch; flat::Bool=false)
     i = Int(pitch)
@@ -185,15 +182,44 @@ function name_to_pitch(name)
     return pitch + x + 12(octave+1) # lowest possible octave is -1 but pitch starts from 0
 end
 """
-    pitch_to_hz(name::String, a4::real) -> Float
+    pitch_to_hz(name::String, a4::Real) -> Float
 Return the frequency value of the given midi note , which can be of the form
-`Integer` where:
+`Real` where:
 
 We define E.g. `midi_to_hz(69) === 440(with the default middle a)` 
 See https://en.wikipedia.org/wiki/Piano_key_frequencies
 and https://librosa.org/doc/main/_modules/librosa/core/convert.html#midi_to_hz.
 """
+function pitch_to_hz(pitch, A4 = 440)
+    return A4 * (2^ ((pitch-69) / 12))
+end
+"""
+    hz_to_pitch(name::String,A4::Real) -> Real
+Return the midi value of the given  frequency
+default middle a is 440hz
+"""
+function hz_to_pitch(freq, A4 = 440)
+    return 12 * (log2(freq) - log2(A4)) + 69
+end
+"""
+hz_to_name(freq::Real,A4::Real) -> String
+Return the note name of the given note frequency
+ie `hz_to_name(440) === "A4"`
+"""
 
+function hz_to_name(freq, A4 = 440)
+   return pitch_to_name(round(hz_to_pitch(freq,A4))) 
+end
+
+"""
+name_to_hz(name::String,A4::Real) -> Real
+Return the frequency of the given note name
+ie `name_to_hz("A4") === 440`
+`name_to_hz("A4",444) === 444`
+"""
+function name_to_hz(name,A4=440)
+    return pitch_to_hz(name_to_pitch(name),A4)
+end
 #######################################################
 # pretty printing
 #######################################################

--- a/src/note.jl
+++ b/src/note.jl
@@ -133,6 +133,10 @@ e.g. `A♯3` is printed as `B♭3`.
 
 Reminder: middle C has pitch `60` and is displayed as `C4`.
 """
+function pitch_to_hz(pitch, a4 = 440)
+    return a4 * (2.0 ^ ((pitch- 69.0) / 12.0))
+end
+
 function pitch_to_name(pitch; flat::Bool=false)
     i = Int(pitch)
     notename = PITCH_TO_NAME[mod(i, 12)]
@@ -180,6 +184,15 @@ function name_to_pitch(name)
     
     return pitch + x + 12(octave+1) # lowest possible octave is -1 but pitch starts from 0
 end
+"""
+    pitch_to_hz(name::String, a4::real) -> Float
+Return the frequency value of the given midi note , which can be of the form
+`Integer` where:
+
+We define E.g. `midi_to_hz(69) === 440(with the default middle a)` 
+See https://en.wikipedia.org/wiki/Piano_key_frequencies
+and https://librosa.org/doc/main/_modules/librosa/core/convert.html#midi_to_hz.
+"""
 
 #######################################################
 # pretty printing

--- a/src/note.jl
+++ b/src/note.jl
@@ -192,7 +192,7 @@ function pitch_to_hz(pitch, A4 = 440)
 end
 
 """
-    hz_to_pitch(name::String, A4::Real = 440) -> Real
+    hz_to_pitch(hz::Real, A4::Real = 440) -> pitch::Int
 Inverse of [`pitch_to_hz`](@ref).
 """
 function hz_to_pitch(freq, A4 = 440)

--- a/src/note.jl
+++ b/src/note.jl
@@ -133,7 +133,6 @@ e.g. `A♯3` is printed as `B♭3`.
 
 Reminder: middle C has pitch `60` and is displayed as `C4`.
 """
-
 function pitch_to_name(pitch; flat::Bool=false)
     i = Int(pitch)
     notename = PITCH_TO_NAME[mod(i, 12)]
@@ -181,45 +180,25 @@ function name_to_pitch(name)
     
     return pitch + x + 12(octave+1) # lowest possible octave is -1 but pitch starts from 0
 end
-"""
-    pitch_to_hz(name::String, a4::Real) -> Float
-Return the frequency value of the given midi note , which can be of the form
-`Real` where:
 
-We define E.g. `midi_to_hz(69) === 440(with the default middle a)` 
+"""
+    pitch_to_hz(name::String, A4::Real = 440) -> Real
+Return the frequency value of the given midi note
 See https://en.wikipedia.org/wiki/Piano_key_frequencies
 and https://librosa.org/doc/main/_modules/librosa/core/convert.html#midi_to_hz.
 """
 function pitch_to_hz(pitch, A4 = 440)
     return A4 * (2^ ((pitch-69) / 12))
 end
+
 """
-    hz_to_pitch(name::String,A4::Real) -> Real
-Return the midi value of the given  frequency
-default middle a is 440hz
+    hz_to_pitch(name::String, A4::Real = 440) -> Real
+Return the midi value of the given frequency
 """
 function hz_to_pitch(freq, A4 = 440)
     return 12 * (log2(freq) - log2(A4)) + 69
 end
-"""
-hz_to_name(freq::Real,A4::Real) -> String
-Return the note name of the given note frequency
-ie `hz_to_name(440) === "A4"`
-"""
 
-function hz_to_name(freq, A4 = 440)
-   return pitch_to_name(round(hz_to_pitch(freq,A4))) 
-end
-
-"""
-name_to_hz(name::String,A4::Real) -> Real
-Return the frequency of the given note name
-ie `name_to_hz("A4") === 440`
-`name_to_hz("A4",444) === 444`
-"""
-function name_to_hz(name,A4=440)
-    return pitch_to_hz(name_to_pitch(name),A4)
-end
 #######################################################
 # pretty printing
 #######################################################

--- a/src/note.jl
+++ b/src/note.jl
@@ -183,7 +183,7 @@ end
 
 """
     pitch_to_hz(pitch::Integer, A4::Real = 440) -> hz::Real
-Return the frequency value of the given midi note
+Return the frequency value of the given midi note, optionally given the reference for middle A.
 See https://en.wikipedia.org/wiki/Piano_key_frequencies
 and https://librosa.org/doc/main/_modules/librosa/core/convert.html#midi_to_hz.
 """

--- a/src/note.jl
+++ b/src/note.jl
@@ -182,7 +182,7 @@ function name_to_pitch(name)
 end
 
 """
-    pitch_to_hz(name::String, A4::Real = 440) -> Real
+    pitch_to_hz(pitch::Integer, A4::Real = 440) -> hz::Real
 Return the frequency value of the given midi note
 See https://en.wikipedia.org/wiki/Piano_key_frequencies
 and https://librosa.org/doc/main/_modules/librosa/core/convert.html#midi_to_hz.

--- a/src/note.jl
+++ b/src/note.jl
@@ -193,7 +193,7 @@ end
 
 """
     hz_to_pitch(name::String, A4::Real = 440) -> Real
-Return the midi value of the given frequency
+Inverse of [`pitch_to_hz`](@ref).
 """
 function hz_to_pitch(freq, A4 = 440)
     return 12 * (log2(freq) - log2(A4)) + 69

--- a/test/note.jl
+++ b/test/note.jl
@@ -32,6 +32,10 @@ end
 
     @test all([name_to_pitch(pitch_to_name(i)) == i for i in 0:255])
 end
+@testset "frequency" begin
+    tol = 10e-5
+    @test pitch_to_hz(3,5)==2
+end
 
 @testset "copying notes" begin
     midi = load("doxy.mid")

--- a/test/note.jl
+++ b/test/note.jl
@@ -42,8 +42,8 @@ end
     #hz to pitch
     @test hz_to_pitch(440) == 69
     @test hz_to_pitch(432,432) == 69
-    @test hz_to_pitch(7040.000) == 117
-    @test hz_to_pitch(123.4708) == 47
+    @test round(hz_to_pitch(7040.000)) == 117
+    @test round(hz_to_pitch(123.4708)) == 47
     
     @test hz_to_name(440) == "A4"
     @test hz_to_name(880) == "A5"

--- a/test/note.jl
+++ b/test/note.jl
@@ -45,15 +45,7 @@ end
     @test round(hz_to_pitch(7040.000)) == 117
     @test round(hz_to_pitch(123.4708)) == 47
     
-    @test hz_to_name(440) == "A4"
-    @test hz_to_name(880) == "A5"
-    @test hz_to_name(220) == "A3"
-    @test hz_to_name(1108.731) == "C♯6"
 
-    @test abs(name_to_hz("D6")-1174.659 ) < tol
-    @test abs(name_to_hz("A7")-3520.000) < tol
-    @test abs(name_to_hz("D3",432)-144.16) < tol
-    @test abs(name_to_hz("G7",432)-3078.95) < tol
 end
 
 @testset "copying notes" begin

--- a/test/note.jl
+++ b/test/note.jl
@@ -33,8 +33,27 @@ end
     @test all([name_to_pitch(pitch_to_name(i)) == i for i in 0:255])
 end
 @testset "frequency" begin
-    tol = 10e-5
-    @test pitch_to_hz(3,5)==2
+    tol = 10e-3
+    @test pitch_to_hz(69,440)==440
+    @test pitch_to_hz(69,432)==432
+    @test abs( pitch_to_hz(44)-103.8262 ) < tol
+    @test abs(pitch_to_hz(105)-3520.000) < tol
+    @test abs(pitch_to_hz(89,432)-1371.51) < tol
+    #hz to pitch
+    @test hz_to_pitch(440) == 69
+    @test hz_to_pitch(432,432) == 69
+    @test hz_to_pitch(7040.000) == 117
+    @test hz_to_pitch(123.4708) == 47
+    
+    @test hz_to_name(440) == "A4"
+    @test hz_to_name(880) == "A5"
+    @test hz_to_name(220) == "A3"
+    @test hz_to_name(1108.731) == "C♯6"
+
+    @test abs(name_to_hz("D6")-1174.659 ) < tol
+    @test abs(name_to_hz("A7")-3520.000) < tol
+    @test abs(name_to_hz("D3",432)-144.16) < tol
+    @test abs(name_to_hz("G7",432)-3078.95) < tol
 end
 
 @testset "copying notes" begin


### PR DESCRIPTION
# Added functions for frequency conversions

functions added support two arguments, one optional with A4 default to 440hz
### pitch_to_hz
* returns the frequency of the given midi note number
### hz_to_pitch
* returns the midi note number of the given frequency.
* I'm unfamiliar with midi, so I was unsure if the value could be a float,
so the function currently could return a float.
### hz_to_name
* Returns a note name based on the given frequency, ie
hz_to_name(440) == "A4"
### name_to_hz
* Returns a frequency based on the given note name
* I was wondering if MIDI.jl should add support for lowercase note names. The 
library I'm most familiar with, librosa, supports lowercase note names



[Based on librosa](https://librosa.org/doc/main/_modules/librosa/core/convert.html)
I wasn't sure where to cite it.